### PR TITLE
Use typechecker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/dist/index.js",
+            "args": [
+            ],
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "sourceMaps": true
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -28,9 +28,13 @@
   ],
   "devDependencies": {
     "@types/node": "^8.0.47",
-    "typescript": "^2.7.0-dev.20171026"
+    "typescript": "^2.7.2"
   },
   "peerDependencies": {
     "typescript": "^2.4.0"
+  },
+  "dependencies": {
+    "tslib": "^1.9.0",
+    "tsutils": "^2.21.2"
   }
 }

--- a/test/fixtures/mixed.d.ts
+++ b/test/fixtures/mixed.d.ts
@@ -1,0 +1,46 @@
+import { WrappedAst } from "tsutils";
+export * from './other';
+export declare function bundle(entry: string): void;
+export declare const nested: number, deeplyNested: number;
+declare let nested2: number;
+export { nested2 };
+export declare let foo: Arr;
+declare const bar: Generic;
+export { bar };
+export declare type Arr = (number | string)[];
+export declare type Generic = Array<number | string>;
+export declare type Callable = {
+    (a: Array<{
+        (): void;
+    }>, ...args: any[]): any;
+};
+export declare type Signature = (a: (() => void)[], ...args: any[]) => any;
+export interface Foo {
+    method(): void;
+    method(param: boolean): string;
+    doStuff(): void;
+    [key: number]: (number | string)[];
+    [key: string]: any;
+}
+export interface Foo2 {
+    method(param: boolean): string;
+    doStuff(): void;
+    [key: string]: any;
+    method(): void;
+    [key: number]: Array<number | string>;
+}
+export declare namespace Extended {
+    function bas(): void;
+}
+export interface Extended {
+    foo: Arr;
+}
+export declare class Extended {
+    baz: void;
+}
+export interface Extended {
+    bar: Generic;
+}
+export declare var wrapped: {
+    wrapped: WrappedAst;
+};

--- a/test/fixtures/mixed.d.ts
+++ b/test/fixtures/mixed.d.ts
@@ -1,6 +1,6 @@
 import { WrappedAst } from "tsutils";
 export { isIdentifier } from 'tsutils';
-export * from './other';
+export { Reexport } from './other';
 export declare function bundle(entry: string): void;
 export declare const nested: number, deeplyNested: number;
 declare let nested2: number;

--- a/test/fixtures/mixed.d.ts
+++ b/test/fixtures/mixed.d.ts
@@ -1,4 +1,5 @@
 import { WrappedAst } from "tsutils";
+export { isIdentifier } from 'tsutils';
 export * from './other';
 export declare function bundle(entry: string): void;
 export declare const nested: number, deeplyNested: number;

--- a/test/fixtures/other.d.ts
+++ b/test/fixtures/other.d.ts
@@ -1,0 +1,10 @@
+import * as ts from 'typescript';
+
+export interface Reexport {
+    foo: number;
+}
+export interface Reexport {
+    bar: string;
+}
+
+export type NodeArray = ts.NodeArray<ts.Node>;

--- a/test/fixtures/other.d.ts
+++ b/test/fixtures/other.d.ts
@@ -4,7 +4,15 @@ export interface Reexport {
     foo: number;
 }
 export interface Reexport {
-    bar: string;
+    bar: IndirectUse;
 }
 
 export type NodeArray = ts.NodeArray<ts.Node>;
+
+export interface IndirectUse {
+    __foo: MoreIndirectUse;
+}
+
+export interface MoreIndirectUse {
+    __bar: NodeArray;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,9 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "inlineSourceMap": false
   },
   "include": [
       "./src"


### PR DESCRIPTION
* emit only exported declarations
* normalize declarations using transformer and pretty printer


TODO

* normalize quotes
* sort members (class, interface, type literal) - static, name, kind - and exports of namespaces
* handle implicit uses
* emit imports/exports from node_modules
* JSDoc comments?
* Use custom CompilerHost to only read d.ts files even if .ts files are availabe